### PR TITLE
Raspbian corebase

### DIFF
--- a/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-build-base-on-raspbian10.sh
+++ b/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-build-base-on-raspbian10.sh
@@ -56,7 +56,8 @@ libstdc++-6-dev \
 gobjc-6 gobjc++-6 \
 gobjc++ \
 libstdc++-6-dev libstdc++-6-doc libstdc++-6-pic \
-libstdc++6 cmake xpdf libxrandr-dev
+libstdc++6 cmake xpdf libxrandr-dev \
+libcurl4-gnutls-dev
 
 if [ "$APPS" = true ] ; then
   sudo apt -y install curl
@@ -154,6 +155,23 @@ showPrompt
 echo -e "\n\n"
 echo -e "${GREEN}Building GNUstep-base...${NC}"
 cd ../libs-base/
+./configure
+make -j8
+sudo -E make install
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
+showPrompt
+
+# Build GNUstep corebase
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-corebase...${NC}"
+
+# helps configure to find objc-runtime include files
+export CFLAGS="$CFLAGS `gnustep-config --objc-flags`"
+
+cd ../libs-corebase/
+make clean
 ./configure
 make -j8
 sudo -E make install

--- a/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-build-base-on-raspbian10.sh
+++ b/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-build-base-on-raspbian10.sh
@@ -171,7 +171,8 @@ echo -e "${GREEN}Building GNUstep-corebase...${NC}"
 export CFLAGS="$CFLAGS `gnustep-config --objc-flags`"
 
 cd ../libs-corebase/
-make clean
+# clean doesn't work the very first time
+# make clean
 ./configure
 make -j8
 sudo -E make install

--- a/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-buildon-raspbian10.sh
+++ b/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-buildon-raspbian10.sh
@@ -196,6 +196,28 @@ cd ../libs-base/
 make -j8
 sudo -E make install
 
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
+showPrompt
+
+# Build GNUstep corebase
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-corebase...${NC}"
+
+# helps configure to find objc-runtime include files
+SAVEDCFLAGS=$CFLAGS
+export CFLAGS="$CFLAGS `gnustep-config --objc-flags`"
+
+cd ../libs-corebase/
+make clean
+./configure
+make -j8
+sudo -E make install
+
+export CFLAGS=$SAVEDFLAGS
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
 showPrompt
 
 # Build GNUstep GUI

--- a/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-buildon-raspbian10.sh
+++ b/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-buildon-raspbian10.sh
@@ -211,7 +211,8 @@ SAVEDCFLAGS=$CFLAGS
 export CFLAGS="$CFLAGS `gnustep-config --objc-flags`"
 
 cd ../libs-corebase/
-make clean
+# clean doesn't work the very first time
+# make clean
 ./configure
 make -j8
 sudo -E make install

--- a/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-buildon-raspbian10.sh
+++ b/raspbian-10-clang-9.0-runtime-2.1-ARM/GNUstep-buildon-raspbian10.sh
@@ -78,7 +78,9 @@ libxt-dev libssl-dev \
 libasound2-dev libjack-dev libjack0 libportaudio2 \
 libportaudiocpp0 portaudio19-dev \
 libstdc++-6-dev libstdc++-6-doc libstdc++-6-pic \
-libstdc++6 cmake xpdf libxrandr-dev
+libstdc++6 cmake xpdf libxrandr-dev \
+libcurl4-gnutls-dev
+     
 
 if [ "$APPS" = true ] ; then
   sudo apt -y install curl


### PR DESCRIPTION
Added dependency library 'libcurl4-gnutls-dev' because MPWFoundation uses 'NSURLSession' which in turn is brought in via configure in 'libs-base'.
Added build of libs-corebase, because MPWFoundation uses CoreFoundation in 'MPWJSONWriter'.

I tested this additions with a PI Zero W and a PI 400.